### PR TITLE
Use one feed source cache, rather than populating a feed source cache…

### DIFF
--- a/src/main/java/com/conveyal/gtfs/api/util/FeedSourceCache.java
+++ b/src/main/java/com/conveyal/gtfs/api/util/FeedSourceCache.java
@@ -1,0 +1,25 @@
+package com.conveyal.gtfs.api.util;
+
+import com.conveyal.gtfs.BaseGTFSCache;
+import com.conveyal.gtfs.GTFSFeed;
+import com.conveyal.gtfs.api.models.FeedSource;
+
+import java.io.File;
+
+/**
+ * Created by matthewc on 4/14/17.
+ */
+public class FeedSourceCache extends BaseGTFSCache<FeedSource> {
+    public FeedSourceCache(String bucket, File cacheDir) {
+        super(bucket, cacheDir);
+    }
+
+    public FeedSourceCache(String bucket, String bucketFolder, File cacheDir) {
+        super(bucket, bucketFolder, cacheDir);
+    }
+
+    @Override
+    protected FeedSource processFeed(GTFSFeed feed) {
+        return new FeedSource(feed);
+    }
+}


### PR DESCRIPTION
… from a GTFS cache.

Depends on the gtfscache-improvements branch of gtfs-lib.