### PR TITLE
Don't swallow exceptions in getFeedSource

### DIFF
--- a/src/main/java/com/conveyal/gtfs/api/controllers/FeedController.java
+++ b/src/main/java/com/conveyal/gtfs/api/controllers/FeedController.java
@@ -1,18 +1,24 @@
 package com.conveyal.gtfs.api.controllers;
 
 import com.conveyal.gtfs.api.ApiMain;
-import com.conveyal.gtfs.model.Agency;
+import com.conveyal.gtfs.api.models.FeedSource;
 import spark.Request;
 import spark.Response;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static spark.Spark.halt;
+
 /**
  * Created by landon on 2/9/16.
  */
 public class FeedController {
+    private static final Logger LOG = LoggerFactory.getLogger(FeedController.class);
+
     public static List<Object> getFeeds(Request req, Response res){
         // return all currently registered feeds if no param specified
         if (req.params().size() == 0 && req.queryParams().size() == 0){
@@ -21,8 +27,13 @@ public class FeedController {
         }
         // get and return specific feed for single param
         if (req.params("id") != null){
-            return ApiMain.getFeedSource(req.params("id")).feed.agency.values().stream()
-                    .collect(Collectors.toList());
+            try {
+                FeedSource feedSource = ApiMain.getFeedSource(req.params("id"));
+                return feedSource.feed.agency.values().stream().collect(Collectors.toList());
+            } catch (Exception e) {
+                LOG.error("Error while retrieving feeds.", e);
+                halt(404, "Error while retrieving feeds. " + e.getMessage());
+            }
         }
         // get and return multiple specified feeds for comma separated list param
         if (req.queryParams("id") != null){

--- a/src/main/java/com/conveyal/gtfs/api/controllers/StopTimesController.java
+++ b/src/main/java/com/conveyal/gtfs/api/controllers/StopTimesController.java
@@ -1,6 +1,5 @@
 package com.conveyal.gtfs.api.controllers;
 
-import com.conveyal.gtfs.GTFSFeed;
 import com.conveyal.gtfs.api.ApiMain;
 import com.conveyal.gtfs.api.models.FeedSource;
 import com.conveyal.gtfs.model.StopTime;
@@ -22,14 +21,18 @@ public class StopTimesController {
             halt(400, "Please specify a feed and trip");
         }
 
-        FeedSource feed = ApiMain.getFeedSource(req.queryParams("feed"));
+        try {
+            FeedSource feed = ApiMain.getFeedSource(req.queryParams("feed"));
 
-        if (feed == null) halt(404, "Feed not found");
+            if (!feed.feed.trips.containsKey(req.params("id"))) halt(404, "Trip not found!");
 
-        if (!feed.feed.trips.containsKey(req.params("id"))) halt(404, "Trip not found!");
+            List<StopTime> ret = new ArrayList<>();
+            feed.feed.getOrderedStopTimesForTrip(req.params("id")).forEach(ret::add);
+            return ret;
+        } catch (Exception e) {
+            halt(404, "Feed not found. " + e.getMessage());
 
-        List<StopTime> ret = new ArrayList<>();
-        feed.feed.getOrderedStopTimesForTrip(req.params("id")).forEach(ret::add);
-        return ret;
+            return null;
+        }
     }
 }

--- a/src/main/java/com/conveyal/gtfs/api/graphql/fetchers/FeedFetcher.java
+++ b/src/main/java/com/conveyal/gtfs/api/graphql/fetchers/FeedFetcher.java
@@ -4,17 +4,18 @@ import com.conveyal.gtfs.api.ApiMain;
 import com.conveyal.gtfs.api.GraphQLMain;
 import com.conveyal.gtfs.api.graphql.WrappedGTFSEntity;
 import com.conveyal.gtfs.api.models.FeedSource;
-import com.conveyal.gtfs.model.Entity;
 import com.conveyal.gtfs.model.FeedInfo;
 import com.vividsolutions.jts.geom.Geometry;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
-import org.apache.commons.dbutils.DbUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.sql.*;
-import java.util.ArrayList;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -87,7 +88,7 @@ public class FeedFetcher implements DataFetcher {
 
     public static Geometry getMergedBuffer(DataFetchingEnvironment env) {
         WrappedGTFSEntity<FeedInfo> feedInfo = (WrappedGTFSEntity<FeedInfo>) env.getSource();
-        FeedSource fs = ApiMain.getFeedSource(feedInfo.feedUniqueId);
+        FeedSource fs = ApiMain.getFeedSourceWithoutExceptions(feedInfo.feedUniqueId);
         if (fs == null) return null;
 
         return fs.feed.getMergedBuffers();
@@ -95,7 +96,7 @@ public class FeedFetcher implements DataFetcher {
 
     public static WrappedGTFSEntity<FeedInfo> forWrappedGtfsEntity (DataFetchingEnvironment env) {
         WrappedGTFSEntity<FeedInfo> feedInfo = (WrappedGTFSEntity<FeedInfo>) env.getSource();
-        FeedSource fs = ApiMain.getFeedSource(feedInfo.feedUniqueId);
+        FeedSource fs = ApiMain.getFeedSourceWithoutExceptions(feedInfo.feedUniqueId);
         if (fs == null) return null;
 
         return getFeedInfo(fs);

--- a/src/main/java/com/conveyal/gtfs/api/graphql/fetchers/PatternFetcher.java
+++ b/src/main/java/com/conveyal/gtfs/api/graphql/fetchers/PatternFetcher.java
@@ -79,7 +79,7 @@ public class PatternFetcher {
     }
     public static List<WrappedGTFSEntity<Pattern>> fromRoute(DataFetchingEnvironment env) {
         WrappedGTFSEntity<Route> route = (WrappedGTFSEntity<Route>) env.getSource();
-        FeedSource fs = ApiMain.getFeedSource(route.feedUniqueId);
+        FeedSource fs = ApiMain.getFeedSourceWithoutExceptions(route.feedUniqueId);
         if (fs == null) return null;
 
         List<String> stopIds = env.getArgument("stop_id");
@@ -108,7 +108,7 @@ public class PatternFetcher {
 
     public static Long fromRouteCount(DataFetchingEnvironment env) {
         WrappedGTFSEntity<Route> route = (WrappedGTFSEntity<Route>) env.getSource();
-        FeedSource fs = ApiMain.getFeedSource(route.feedUniqueId);
+        FeedSource fs = ApiMain.getFeedSourceWithoutExceptions(route.feedUniqueId);
         if (fs == null) return null;
 
         return fs.feed.patterns.values().stream()
@@ -118,7 +118,7 @@ public class PatternFetcher {
 
     public static WrappedGTFSEntity<Pattern> fromTrip(DataFetchingEnvironment env) {
         WrappedGTFSEntity<Trip> trip = (WrappedGTFSEntity<Trip>) env.getSource();
-        FeedSource fs = ApiMain.getFeedSource(trip.feedUniqueId);
+        FeedSource fs = ApiMain.getFeedSourceWithoutExceptions(trip.feedUniqueId);
         if (fs == null) return null;
 
         Pattern patt = fs.feed.patterns.get(fs.feed.tripPatternMap.get(trip.entity.trip_id));

--- a/src/main/java/com/conveyal/gtfs/api/graphql/fetchers/RouteFetcher.java
+++ b/src/main/java/com/conveyal/gtfs/api/graphql/fetchers/RouteFetcher.java
@@ -1,6 +1,5 @@
 package com.conveyal.gtfs.api.graphql.fetchers;
 
-import com.conveyal.gtfs.GTFSFeed;
 import com.conveyal.gtfs.api.ApiMain;
 import com.conveyal.gtfs.api.graphql.WrappedGTFSEntity;
 import com.conveyal.gtfs.api.models.FeedSource;
@@ -52,7 +51,7 @@ public class RouteFetcher {
         WrappedGTFSEntity<Stop> stop = (WrappedGTFSEntity<Stop>) environment.getSource();
         List<String> routeIds = environment.getArgument("route_id");
 
-        FeedSource fs = ApiMain.getFeedSource(stop.feedUniqueId);
+        FeedSource fs = ApiMain.getFeedSourceWithoutExceptions(stop.feedUniqueId);
         if (fs == null) return null;
 
         List<WrappedGTFSEntity<Route>> routes = fs.feed.patterns.values().stream()
@@ -76,7 +75,7 @@ public class RouteFetcher {
         WrappedGTFSEntity<Pattern> pattern = (WrappedGTFSEntity<Pattern>) env.getSource();
         List<String> routeIds = env.getArgument("route_id");
 
-        FeedSource fs = ApiMain.getFeedSource(pattern.feedUniqueId);
+        FeedSource fs = ApiMain.getFeedSourceWithoutExceptions(pattern.feedUniqueId);
         if (fs == null) return null;
 
         return new WrappedGTFSEntity<>(fs.id, fs.feed.routes.get(pattern.entity.route_id));
@@ -86,7 +85,7 @@ public class RouteFetcher {
         WrappedGTFSEntity<FeedInfo> fi = (WrappedGTFSEntity<FeedInfo>) environment.getSource();
         List<String> routeIds = environment.getArgument("route_id");
 
-        FeedSource fs = ApiMain.getFeedSource(fi.feedUniqueId);
+        FeedSource fs = ApiMain.getFeedSourceWithoutExceptions(fi.feedUniqueId);
         if (fs == null) return null;
 
         if (routeIds != null) {
@@ -106,7 +105,7 @@ public class RouteFetcher {
     public static Long fromFeedCount(DataFetchingEnvironment environment) {
         WrappedGTFSEntity<FeedInfo> fi = (WrappedGTFSEntity<FeedInfo>) environment.getSource();
 
-        FeedSource fs = ApiMain.getFeedSource(fi.feedUniqueId);
+        FeedSource fs = ApiMain.getFeedSourceWithoutExceptions(fi.feedUniqueId);
         if (fs == null) return null;
 
         return fs.feed.routes.values().stream().count();

--- a/src/main/java/com/conveyal/gtfs/api/graphql/fetchers/StatFetcher.java
+++ b/src/main/java/com/conveyal/gtfs/api/graphql/fetchers/StatFetcher.java
@@ -27,7 +27,7 @@ import static com.conveyal.gtfs.api.util.GraphQLUtil.argumentDefined;
 public class StatFetcher {
     public static StopStatistic fromStop(DataFetchingEnvironment env) {
         WrappedGTFSEntity<Stop> stop = (WrappedGTFSEntity<Stop>) env.getSource();
-        FeedSource fs = ApiMain.getFeedSource(stop.feedUniqueId);
+        FeedSource fs = ApiMain.getFeedSourceWithoutExceptions(stop.feedUniqueId);
         if (fs == null) return null;
 
         if (argumentDefined(env, "date") && argumentDefined(env, "from") && argumentDefined(env, "to")) {
@@ -48,7 +48,7 @@ public class StatFetcher {
 
     public static RouteStatistic fromRoute(DataFetchingEnvironment env) {
         WrappedGTFSEntity<Route> route = (WrappedGTFSEntity<Route>) env.getSource();
-        FeedSource fs = ApiMain.getFeedSource(route.feedUniqueId);
+        FeedSource fs = ApiMain.getFeedSourceWithoutExceptions(route.feedUniqueId);
         if (fs == null) return null;
 
         if (argumentDefined(env, "date") && argumentDefined(env, "from") && argumentDefined(env, "to")) {
@@ -69,7 +69,7 @@ public class StatFetcher {
 
     public static PatternStatistic fromPattern(DataFetchingEnvironment env) {
         WrappedGTFSEntity<Pattern> pattern = (WrappedGTFSEntity<Pattern>) env.getSource();
-        FeedSource fs = ApiMain.getFeedSource(pattern.feedUniqueId);
+        FeedSource fs = ApiMain.getFeedSourceWithoutExceptions(pattern.feedUniqueId);
         if (fs == null) return null;
 
         if (argumentDefined(env, "date") && argumentDefined(env, "from") && argumentDefined(env, "to")) {
@@ -90,7 +90,7 @@ public class StatFetcher {
 
     public static List<TransferPerformanceSummary> getTransferPerformance(DataFetchingEnvironment env) {
         WrappedGTFSEntity<Stop> stop = (WrappedGTFSEntity<Stop>) env.getSource();
-        FeedSource fs = ApiMain.getFeedSource(stop.feedUniqueId);
+        FeedSource fs = ApiMain.getFeedSourceWithoutExceptions(stop.feedUniqueId);
         if (fs == null) return null;
 
         if (argumentDefined(env, "date")) {
@@ -104,7 +104,7 @@ public class StatFetcher {
 
     public static FeedStatistic fromFeed(DataFetchingEnvironment env) {
         WrappedGTFSEntity<FeedInfo> feedInfo = (WrappedGTFSEntity<FeedInfo>) env.getSource();
-        FeedSource fs = ApiMain.getFeedSource(feedInfo.feedUniqueId);
+        FeedSource fs = ApiMain.getFeedSourceWithoutExceptions(feedInfo.feedUniqueId);
         if (fs == null) return null;
 
         if (argumentDefined(env, "date") && argumentDefined(env, "from") && argumentDefined(env, "to")) {

--- a/src/main/java/com/conveyal/gtfs/api/graphql/fetchers/StopFetcher.java
+++ b/src/main/java/com/conveyal/gtfs/api/graphql/fetchers/StopFetcher.java
@@ -121,7 +121,7 @@ public class StopFetcher {
             return Collections.emptyList();
         }
 
-        FeedSource fs = ApiMain.getFeedSource(pattern.feedUniqueId);
+        FeedSource fs = ApiMain.getFeedSourceWithoutExceptions(pattern.feedUniqueId);
         if (fs == null) return null;
 
         return fs.feed.getOrderedStopListForTrip(pattern.entity.associatedTrips.get(0))
@@ -140,7 +140,7 @@ public class StopFetcher {
             return 0L;
         }
 
-        FeedSource fs = ApiMain.getFeedSource(pattern.feedUniqueId);
+        FeedSource fs = ApiMain.getFeedSourceWithoutExceptions(pattern.feedUniqueId);
         if (fs == null) return null;
 
         return fs.feed.getOrderedStopListForTrip(pattern.entity.associatedTrips.get(0))
@@ -149,7 +149,7 @@ public class StopFetcher {
 
     public static List<WrappedGTFSEntity<Stop>> fromFeed(DataFetchingEnvironment env) {
         WrappedGTFSEntity<FeedInfo> fi = (WrappedGTFSEntity<FeedInfo>) env.getSource();
-        FeedSource fs = ApiMain.getFeedSource(fi.feedUniqueId);
+        FeedSource fs = ApiMain.getFeedSourceWithoutExceptions(fi.feedUniqueId);
         if (fs == null) return null;
 
         Collection<Stop> stops = fs.feed.stops.values();
@@ -179,7 +179,7 @@ public class StopFetcher {
 
     public static Long fromFeedCount(DataFetchingEnvironment env) {
         WrappedGTFSEntity<FeedInfo> fi = (WrappedGTFSEntity<FeedInfo>) env.getSource();
-        FeedSource fs = ApiMain.getFeedSource(fi.feedUniqueId);
+        FeedSource fs = ApiMain.getFeedSourceWithoutExceptions(fi.feedUniqueId);
         if (fs == null) return null;
 
         Collection<Stop> stops = fs.feed.stops.values();

--- a/src/main/java/com/conveyal/gtfs/api/graphql/fetchers/StopTimeFetcher.java
+++ b/src/main/java/com/conveyal/gtfs/api/graphql/fetchers/StopTimeFetcher.java
@@ -3,26 +3,16 @@ package com.conveyal.gtfs.api.graphql.fetchers;
 import com.conveyal.gtfs.api.ApiMain;
 import com.conveyal.gtfs.api.graphql.WrappedGTFSEntity;
 import com.conveyal.gtfs.api.models.FeedSource;
-import com.conveyal.gtfs.model.Pattern;
 import com.conveyal.gtfs.model.Stop;
 import com.conveyal.gtfs.model.StopTime;
 import com.conveyal.gtfs.model.Trip;
 import graphql.schema.DataFetchingEnvironment;
-import org.mapdb.Fun;
 
-import java.time.Instant;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Set;
-import java.util.SortedSet;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -63,7 +53,7 @@ public class StopTimeFetcher {
     }
     public static List<WrappedGTFSEntity<StopTime>> fromTrip(DataFetchingEnvironment env) {
         WrappedGTFSEntity<Trip> trip = (WrappedGTFSEntity<Trip>) env.getSource();
-        FeedSource fs = ApiMain.getFeedSource(trip.feedUniqueId);
+        FeedSource fs = ApiMain.getFeedSourceWithoutExceptions(trip.feedUniqueId);
         if (fs == null) return null;
 
         List<String> stopIds = env.getArgument("stop_id");
@@ -85,7 +75,7 @@ public class StopTimeFetcher {
 
     public static List<WrappedGTFSEntity<StopTime>> fromStop (DataFetchingEnvironment env) {
         WrappedGTFSEntity<Stop> stop = (WrappedGTFSEntity<Stop>) env.getSource();
-        FeedSource fs = ApiMain.getFeedSource(stop.feedUniqueId);
+        FeedSource fs = ApiMain.getFeedSourceWithoutExceptions(stop.feedUniqueId);
         if (fs == null) return null;
 
         String d = env.getArgument("date");

--- a/src/main/java/com/conveyal/gtfs/api/graphql/fetchers/TripDataFetcher.java
+++ b/src/main/java/com/conveyal/gtfs/api/graphql/fetchers/TripDataFetcher.java
@@ -1,18 +1,14 @@
 package com.conveyal.gtfs.api.graphql.fetchers;
 
-import com.conveyal.gtfs.GTFSFeed;
 import com.conveyal.gtfs.api.ApiMain;
 import com.conveyal.gtfs.api.graphql.WrappedGTFSEntity;
 import com.conveyal.gtfs.api.models.FeedSource;
 import com.conveyal.gtfs.model.Agency;
 import com.conveyal.gtfs.model.Pattern;
 import com.conveyal.gtfs.model.Route;
-import com.conveyal.gtfs.model.Service;
 import com.conveyal.gtfs.model.StopTime;
 import com.conveyal.gtfs.model.Trip;
-import graphql.execution.ExecutionContext;
 import graphql.schema.DataFetchingEnvironment;
-import graphql.schema.GraphQLType;
 import org.mapdb.Fun;
 
 import java.time.LocalDate;
@@ -26,8 +22,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
-import java.time.temporal.ChronoUnit.*;
 
 import static spark.Spark.halt;
 
@@ -72,7 +66,7 @@ public class TripDataFetcher {
      */
     public static List<WrappedGTFSEntity<Trip>> fromRoute(DataFetchingEnvironment dataFetchingEnvironment) {
         WrappedGTFSEntity<Route> route = (WrappedGTFSEntity<Route>) dataFetchingEnvironment.getSource();
-        FeedSource fs = ApiMain.getFeedSource(route.feedUniqueId);
+        FeedSource fs = ApiMain.getFeedSourceWithoutExceptions(route.feedUniqueId);
         if (fs == null) return null;
 
         return fs.feed.trips.values().stream()
@@ -83,7 +77,7 @@ public class TripDataFetcher {
 
     public static Long fromRouteCount(DataFetchingEnvironment dataFetchingEnvironment) {
         WrappedGTFSEntity<Route> route = (WrappedGTFSEntity<Route>) dataFetchingEnvironment.getSource();
-        FeedSource fs = ApiMain.getFeedSource(route.feedUniqueId);
+        FeedSource fs = ApiMain.getFeedSourceWithoutExceptions(route.feedUniqueId);
         if (fs == null) return null;
 
         return fs.feed.trips.values().stream()
@@ -93,7 +87,7 @@ public class TripDataFetcher {
 
     public static WrappedGTFSEntity<Trip> fromStopTime (DataFetchingEnvironment env) {
         WrappedGTFSEntity<StopTime> stopTime = (WrappedGTFSEntity<StopTime>) env.getSource();
-        FeedSource fs = ApiMain.getFeedSource(stopTime.feedUniqueId);
+        FeedSource fs = ApiMain.getFeedSourceWithoutExceptions(stopTime.feedUniqueId);
         if (fs == null) return null;
 
         Trip trip = fs.feed.trips.get(stopTime.entity.trip_id);
@@ -103,7 +97,7 @@ public class TripDataFetcher {
 
     public static List<WrappedGTFSEntity<Trip>> fromPattern (DataFetchingEnvironment env) {
         WrappedGTFSEntity<Pattern> pattern = (WrappedGTFSEntity<Pattern>) env.getSource();
-        FeedSource fs = ApiMain.getFeedSource(pattern.feedUniqueId);
+        FeedSource fs = ApiMain.getFeedSourceWithoutExceptions(pattern.feedUniqueId);
         if (fs == null) return null;
 
         Long beginTime = env.getArgument("begin_time");
@@ -148,7 +142,7 @@ public class TripDataFetcher {
     public static Long fromPatternCount (DataFetchingEnvironment env) {
         WrappedGTFSEntity<Pattern> pattern = (WrappedGTFSEntity<Pattern>) env.getSource();
 
-        FeedSource fs = ApiMain.getFeedSource(pattern.feedUniqueId);
+        FeedSource fs = ApiMain.getFeedSourceWithoutExceptions(pattern.feedUniqueId);
         if (fs == null) return null;
 
         return pattern.entity.associatedTrips.stream().map(fs.feed.trips::get).count();
@@ -156,7 +150,7 @@ public class TripDataFetcher {
 
     public static Integer getStartTime(DataFetchingEnvironment env) {
         WrappedGTFSEntity<Trip> trip = (WrappedGTFSEntity<Trip>) env.getSource();
-        FeedSource fs = ApiMain.getFeedSource(trip.feedUniqueId);
+        FeedSource fs = ApiMain.getFeedSourceWithoutExceptions(trip.feedUniqueId);
         if (fs == null) return null;
 
         Map.Entry<Fun.Tuple2, StopTime> st = fs.feed.stop_times.ceilingEntry(new Fun.Tuple2(trip.entity.trip_id, null));
@@ -165,7 +159,7 @@ public class TripDataFetcher {
 
     public static Integer getDuration(DataFetchingEnvironment env) {
         WrappedGTFSEntity<Trip> trip = (WrappedGTFSEntity<Trip>) env.getSource();
-        FeedSource fs = ApiMain.getFeedSource(trip.feedUniqueId);
+        FeedSource fs = ApiMain.getFeedSourceWithoutExceptions(trip.feedUniqueId);
         if (fs == null) return null;
 
         Integer startTime = getStartTime(env);

--- a/src/main/java/com/conveyal/gtfs/api/util/FeedSourceCache.java
+++ b/src/main/java/com/conveyal/gtfs/api/util/FeedSourceCache.java
@@ -22,4 +22,9 @@ public class FeedSourceCache extends BaseGTFSCache<FeedSource> {
     protected FeedSource processFeed(GTFSFeed feed) {
         return new FeedSource(feed);
     }
+
+    @Override
+    public GTFSFeed getFeed (String id) {
+        return this.get(id).feed;
+    }
 }


### PR DESCRIPTION
The main changeset here is from modifying `FeedSourceCache.getFeedSource` to no longer swallow exceptions. The updates come in two different forms:

1. Add `try`/`catch` blocks around it's usage and handle the errors appropriately. 
2. Switch to `FeedSourceCache.getFeedSourceWithoutExceptions` that explicitly does not throw an exception. It logs the error and returns null. All of the places that it has been switched to that function here are inside the GraphQL code and `null` is checked afterwards.

Other changes:

* Implement the new `getFeed` method from: https://github.com/conveyal/gtfs-lib/pull/67
* Return the `FeedSourceCache` that's created when the Api is initialized
* Add `halt`s to the controllers when errors occur
* Refactor code in places where the `FeedSource`s are retrieved and re-retrieved later in code